### PR TITLE
Fix documentation generation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+* Suppressed warnings in npm (npm writes warnings to stdErr stream and Appveyor fails the builds if anything is in stdErr stream)
+
 ## 2.0
 
 * Initial release on GH

--- a/src/Keith/New-GitBook.ps1
+++ b/src/Keith/New-GitBook.ps1
@@ -63,7 +63,14 @@ function New-GitBook
         }
 
         Push-Location $TempPath
-        Resolve-Path .
+        $currentPath = Resolve-Path .
+
+        # Write npm config file to suppress warn logs
+        # npm writes warning to stderr stream, which is watched by Appveyor for build failure recognition
+        # all measures to reroute stderr to stdout stream had no effect when used inside a ps module
+        # (although they were succesfullym, if the rerouting happened in a ps cmd called by Appveyor directly)
+        "loglevel=error" | Out-File "$currentPath\.npmrc" -Encoding UTF8
+
         npm install gitbook-cli
         Pop-Location
 

--- a/src/Keith/New-GitBook.ps1
+++ b/src/Keith/New-GitBook.ps1
@@ -66,9 +66,9 @@ function New-GitBook
         $currentPath = Resolve-Path .
 
         # Write npm config file to suppress warn logs
-        # npm writes warning to stderr stream, which is watched by Appveyor for build failure recognition
+        # npm writes warnings to stderr stream, which is watched by Appveyor for build failure recognition
         # all measures to reroute stderr to stdout stream had no effect when used inside a ps module
-        # (although they were succesfullym, if the rerouting happened in a ps cmd called by Appveyor directly)
+        # (although rerouting worked in a ps cmd called by Appveyor directly).
         "loglevel=error" | Out-File "$currentPath\.npmrc" -Encoding UTF8
 
         npm install gitbook-cli


### PR DESCRIPTION
This is a fix for the interpretion of gitbook output as error in CI Builds fore all BOB machines. I would tag it as hotfix version 2.0.2 after merge has been applied. If you prefer to release it another version, there should be done an adjustement in the changelog where version 2.0.2 has been assumed as next one.