### PR TITLE
Speed up build time with ensure "WinVerifyTrust" isn't triggered for each project and file while building projects

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,6 @@ build_script:
   - cmd: nuget pack %Nuspec_File% -version "%GitVersion_NuGetVersionV2%" -OutputDirectory %Artefact_Output_Dir%
   - ps: |
       $ErrorActionPreference = 'Stop';
-      New-Item -ItemType Directory -Force -Path "C:\Templates";
       .\generateDocs.ps1
   - 7z a -r %Artefact_Output_Dir%\docs.zip %APPVEYOR_BUILD_FOLDER%\docs-generated\_book
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,6 @@ To integrate Keith in a bob machine, simply add a paket dependency to "Unic.Bob.
 
     param($username, $password, [switch]$Buildserver)
 
-    $PSScriptRoot = split-path -parent $MyInvocation.MyCommand.Definition
-
     $module = "MyModuleName"
 
     Import-Module "$PSScriptRoot\packages\Unic.Bob.Keith\Keith"

--- a/generateDocs.ps1
+++ b/generateDocs.ps1
@@ -1,6 +1,4 @@
-﻿$PSScriptRoot = split-path -parent $MyInvocation.MyCommand.Definition
-
-$module = "Keith"
+﻿$module = "Keith"
 
 Import-Module "$PSScriptRoot\src\$module" -Force
 

--- a/restore.ps1
+++ b/restore.ps1
@@ -1,6 +1,3 @@
-$Invocation = (Get-Variable MyInvocation -Scope 0).Value
-$PSScriptRoot = Split-Path $Invocation.MyCommand.Path
-
 $paketFolder = "$PSScriptRoot\.paket"
 $paketBoot = "$paketFolder\paket.bootstrapper.exe"
 

--- a/src/Keith/Keith.psm1
+++ b/src/Keith/Keith.psm1
@@ -1,5 +1,4 @@
 $ErrorActionPreference = "Stop"
-$PSScriptRoot = Split-Path  $script:MyInvocation.MyCommand.Path
 
 Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.tests.ps1 | Foreach-Object{ . ([scriptblock]::Create([io.file]::ReadAllText($_.FullName))) }
 Export-ModuleMember -Function * -Alias *


### PR DESCRIPTION
Since few weeks we faced the issue that projects are built much slower then usually. This is a fix for that.